### PR TITLE
Use default go test timeout

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -75,7 +75,6 @@ func cover(tags []string) error {
 		"-covermode=atomic",
 		"-coverprofile=" + coverFile,
 		"-race",
-		"-timeout=60s",
 	}
 
 	if len(tags) > 0 {


### PR DESCRIPTION
The current hardcoded value (60s) seems to be the cause for some Direction service Jenkins timeouts.
We could allow it to be passed as a parameter but that will break the API, so I opted for removing it completely and using the default value of 10m.