### PR TITLE
Revert to debian based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine
+FROM golang:1.15
 
 RUN apt-get -y update
 


### PR DESCRIPTION
This fixes the last release by reverting to a debian based image. We can address the move to alpine separately, if we even want to continue using this image at all.