### PR TITLE
DIS-1620 Add mongodb replica set support

### DIFF
--- a/docker/container/mongodb/container.go
+++ b/docker/container/mongodb/container.go
@@ -90,6 +90,7 @@ func (c *Container) Start(pool *dockertest.Pool, networkID string, expiration ui
 		if err != nil {
 			return fmt.Errorf("failed to create mongo client: %w", err)
 		}
+		defer func() { _ = cl.Disconnect(context.Background()) }()
 
 		if err := cl.Ping(context.Background(), nil); err != nil {
 			return fmt.Errorf("could not ping mongo: %w", err)

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -179,7 +179,7 @@ func newTestComponent(prefix, existingNetworkID string, containerHost, useExpira
 	testComponent.WithContainer(mongoContainer)
 
 	mongoReplicaSetContainer, err := mongodb.NewContainer(mongodb.Params{
-		Prefix:         prefix,
+		Prefix:         prefix + "rs",
 		ContainerHost:  containerHost,
 		Version:        "4.2",
 		UseExpiration:  useExpiration,


### PR DESCRIPTION
Since replica needs to be accessible from both the container and the host, there is a new random port is used to spinup mongodb.
