### PR TITLE
Docker Action Fix

### DIFF
--- a/.github/workflows/bake-docker.yml
+++ b/.github/workflows/bake-docker.yml
@@ -9,14 +9,12 @@ jobs:
     steps:      
       - name: Check out source code
         uses: actions/checkout@v2
-      - name: Get release version
-        id: get_version
-        # Expect release tags to be in semver format with a 'v' prefix.
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:11})
       - name: Build and Publish to Dockerhub
+        # Expect release tags to be in semver format with a 'v' prefix.
+        pre: echo ::save-state name=RELEASE_VERSION::$(echo ${GITHUB_REF:11})
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
           name: taxibeat/bake
           username: ${{ secrets.DOCKERHUBUSER }}
           password: ${{ secrets.DOCKERHUBPWD }}
-          tags: "latest,${{ env.RELEASE_VERSION }}"
+          tags: "latest,${{ env.STATE_RELEASE_VERSION }}"


### PR DESCRIPTION
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
- https://github.com/elgohr/Publish-Docker-Github-Action/commit/e6b13fed50fe4c33923141f6b1884cacfc3bb346