### PR TITLE
Sequential component and integration tests

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -106,5 +106,5 @@ func getBuildTagFlag(buildTags []string) string {
 }
 
 func getParallelFlag(n int) string {
-	return fmt.Sprintf("-p=%d", n)
+	return fmt.Sprintf("-parallel=%d", n)
 }


### PR DESCRIPTION
Adds `-parallel=1` flag to default test args (used for component and integration tests). 
This ensures that repos with multiple component or integration tests behave predictably by executing those tests sequentially.
Unit tests target is not affected.