### PR TITLE
Fix test parallel programs flag

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -11,10 +11,10 @@ import (
 )
 
 const (
-	goCmd              = "go"
-	defaultPkg         = "./..."
-	coverFile          = "coverage.txt"
-	defaultParallelism = 1
+	goCmd        = "go"
+	defaultPkg   = "./..."
+	coverFile    = "coverage.txt"
+	defaultPFlag = 1
 )
 
 // DefaultTestArgs used when running tests.
@@ -45,7 +45,7 @@ func Run(tags, extraArgs []string, pkg string) error {
 func RunDefault() error {
 	args := DefaultTestArgs
 	args = append(args, getBuildTagFlag(build.DefaultTags))
-	args = append(args, getParallelFlag(defaultParallelism))
+	args = append(args, getPFlag(defaultPFlag))
 	args = append(args, defaultPkg)
 	return run(args)
 }
@@ -105,6 +105,10 @@ func getBuildTagFlag(buildTags []string) string {
 	return "-tags=" + strings.Join(buildTags, ",")
 }
 
-func getParallelFlag(n int) string {
-	return fmt.Sprintf("-parallel=%d", n)
+// The -p flag controls the
+// the number of programs, such as build commands or
+// test binaries, that can be run in parallel.
+// The default is the number of CPUs available.
+func getPFlag(n int) string {
+	return fmt.Sprintf("-p=%d", n)
 }


### PR DESCRIPTION
In a previous PR I made the mistake of thinking that the go test '-parallel' was simply the long form of the '-p' flag, but it isn't.

-parallel controls the max simultaneous tests that set t.Parallel, inside a pkg.
-p controls how many test binaries run, which translates to how many pkgs get tested in parallel.

In our case we're interested in forcing `-p=1` so that only one test _program_ executes in parallel. This will ensure that only tests explicitly marked to be parallel will actually run in parallel (unless the -parallel flag disallows it), since only one test program will be executed. 

This is what we want for the `test:all` target because it includes component and integration tests that should be run sequentially in order to simplify docker resource management and system load.


```
go help testflag

...
-parallel n
    Allow parallel execution of test functions that call t.Parallel.
    The value of this flag is the maximum number of tests to run
    simultaneously; by default, it is set to the value of GOMAXPROCS.
    Note that -parallel only applies within a single test binary.
    The 'go test' command may run tests for different packages
    in parallel as well, according to the setting of the -p flag
    (see 'go help build').
...
```

```
go help build

...
-p n
        the number of programs, such as build commands or
        test binaries, that can be run in parallel.
        The default is the number of CPUs available.
...
```