### PR TITLE
CI Sequential tests

### DIFF
--- a/ci/test.go
+++ b/ci/test.go
@@ -15,6 +15,7 @@ func runTests(cf string, tags []string) error {
 	args := []string{
 		"test",
 		"-mod=vendor",
+		"-p=1",
 		"-count=1",
 		"-cover",
 		"-coverprofile=" + cf,


### PR DESCRIPTION
Same change as in earlier commits, to add `-p`, this time in the CI target.