### PR TITLE
Use RunV in cover helper

### DIFF
--- a/test/test.go
+++ b/test/test.go
@@ -85,7 +85,7 @@ func cover(tags []string) error {
 
 	fmt.Printf("Executing cmd: %s %s\n", goCmd, strings.Join(args, " "))
 
-	err := sh.Run(goCmd, args...)
+	err := sh.RunV(goCmd, args...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We were using the wrong Run method in the coverage helper, which didn't pipe stdout/err correctly.