### PR TITLE
Remove skim from dockerfile for now

### DIFF
--- a/.github/workflows/bake-docker.yml
+++ b/.github/workflows/bake-docker.yml
@@ -19,4 +19,3 @@ jobs:
           username: ${{ secrets.DOCKERHUBUSER }}
           password: ${{ secrets.DOCKERHUBPWD }}
           tags: "latest,${{ env.RELEASE_VERSION }}"
-          buildargs: GH_TOKEN=${{ secrets.MATCHING_GITHUBTOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,18 +23,6 @@ ENV CGO_ENABLED=1
 # Required to access private modules
 ENV GOPRIVATE=github.com/taxibeat/*
 
-# expect a build-time variable
-ARG GH_TOKEN
-
-# Access to Beat private repos
-RUN git config --global url."https://$GH_TOKEN@github.com/".insteadOf "https://github.com/"
-
-# Download and install skim - proto schema registry tool
-RUN go get github.com/taxibeat/skim/cmd/skim
-
-# Remove token from config after accessing private repos.
-RUN git config --global --remove-section url."https://$GH_TOKEN@github.com/"
-
 # Download and install mage file into bin path
 RUN wget -qc https://github.com/magefile/mage/releases/download/v1.11.0/mage_1.11.0_Linux-64bit.tar.gz -O - | tar -xz -C /usr/bin mage
 


### PR DESCRIPTION
This PR removes skim from the docker image completely.

Skim support inside the Bake Docker image is broken. Let's use those targets via mage and add proper docker support later, after moving the bake image to a private repository.