### PR TITLE
Remove temp container when building

### DIFF
--- a/docker/simplecomponent.go
+++ b/docker/simplecomponent.go
@@ -74,11 +74,11 @@ func (c *SimpleComponent) runContainer(session *Session, conf SimpleContainerCon
 
 	if conf.BuildOpts != nil {
 		err := pool.Client.BuildImage(docker.BuildImageOptions{
-			Name:         c.Name + ":" + session.id,
-			Dockerfile:   conf.BuildOpts.Dockerfile,
-			OutputStream: ioutil.Discard,
-			ContextDir:   conf.BuildOpts.ContextDir,
-			BuildArgs:    conf.BuildOpts.BuildArgs,
+			Name:           c.Name + ":" + session.id,
+			Dockerfile:     conf.BuildOpts.Dockerfile,
+			OutputStream:   ioutil.Discard,
+			ContextDir:     conf.BuildOpts.ContextDir,
+			BuildArgs:      conf.BuildOpts.BuildArgs,
 			RmTmpContainer: true,
 		})
 		if err != nil {


### PR DESCRIPTION
Please sign your commits following this [guide](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification).

Every time we are building our services the temp container (builder) is not removed resulting in a big list of images locally.
