### PR TITLE
Add ineffassign and structcheck Go linters

### DIFF
--- a/targets/lint/golang/go.go
+++ b/targets/lint/golang/go.go
@@ -33,6 +33,8 @@ linters:
     - unconvert
     - errcheck
     - deadcode
+    - ineffassign
+    - structcheck
 
 issues:
   exclude-use-default: false


### PR DESCRIPTION
Add ineffassign and structcheck to the default golangci-lint config.

https://golangci-lint.run/usage/linters/
