### PR TITLE
Add support for private subpackages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM golang:1.17 as builder
 
 ARG GH_TOKEN
 
+# Required to access private modules
+ENV GOPRIVATE=github.com/taxibeat/**
+
 # Install Skim
-ENV GOPRIVATE=github.com/taxibeat/*
 RUN git config --global url."https://$GH_TOKEN@github.com/".insteadOf "https://github.com/" && \
     go get github.com/taxibeat/skim/cmd/skim && rm -rf /go/src/github.com/taxibeat/ && \
     git config --global --remove-section url."https://$GH_TOKEN@github.com/"
@@ -35,9 +37,6 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
 
 # CGO is required by some modules like https://github.com/uber/h3-go
 ENV CGO_ENABLED=1
-
-# Required to access private modules
-ENV GOPRIVATE=github.com/taxibeat/*
 
 # Skim dependencies
 ARG BUF_VERSION=0.24.0


### PR DESCRIPTION
In geofence-portal I started seeing these errors with Bake `v0.19.0`:

```
github.com/taxibeat/geofence-portal/internal/infra/kafka imports
        github.com/taxibeat/beatevents/gosdk: reading github.com/taxibeat/beatevents/gosdk/gosdk/go.mod at revision gosdk/v0.4.0: git fetch -f origin refs/heads/*:refs/he
ads/* refs/tags/*:refs/tags/* in /go/pkg/mod/cache/vcs/7a5a6f47083e1c49b7c6bf18055a2634a28027b20c04588498c948090561905d: exit status 128:
        fatal: remote error: access denied or repository not exported: /0/nw/05/07/f2/282622922/276451112.git
```

Which is related to the fact that `github.com/taxibeat/beatevents/gosdk/gosdk/go.mod` is in a subdirectory of the repo.

The fix is to set GOPRIVATE to `github.com/taxibeat/**`.