### PR TITLE
[Swaggo] Support parseVendor flag

### DIFF
--- a/targets/swagger/swagger.go
+++ b/targets/swagger/swagger.go
@@ -19,7 +19,8 @@ var (
 	// APIDir is the final directory.
 	APIDir = "api"
 	// MainGo is the path to the application entrypoint.
-	MainGo    = ""
+	MainGo = ""
+	// ExtraArgs passed to the swag command.
 	ExtraArgs = []string{"--parseVendor"}
 )
 


### PR DESCRIPTION
Allows for extra args to be passed to the `swaggo` command, by default it enables the `parseVendor` flag which adds support for imported (and vendored) types to be used in responses. This is required in Geofence Portal.