### PR TITLE
Bump component tests retry timeout

### DIFF
--- a/docker/simplecomponent.go
+++ b/docker/simplecomponent.go
@@ -168,7 +168,7 @@ func (c *SimpleComponent) runContainer(session *Session, conf SimpleContainerCon
 func Retry(op func() error) error {
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxInterval = time.Second * 2
-	bo.MaxElapsedTime = time.Minute
+	bo.MaxElapsedTime = 5 * time.Minute
 	return backoff.Retry(op, bo)
 }
 


### PR DESCRIPTION
For some reason, we can't run our CI job anymore in Jenkins. The advice is to bump the retry timeout.

See https://taxibeat.slack.com/archives/C015GBWQ7U3/p1644311362733709