### PR TITLE
Pin mockserver image tag

### DIFF
--- a/docker/component/mockserver/component.go
+++ b/docker/component/mockserver/component.go
@@ -19,7 +19,7 @@ func NewComponent(opts ...docker.SimpleContainerOptionFunc) *docker.SimpleCompon
 	container := docker.SimpleContainerConfig{
 		Name:       componentName,
 		Repository: "mockserver/mockserver",
-		Tag:        "latest",
+		Tag:        "mockserver-5.12.0",
 		Env: []string{
 			"LOG_LEVEL=DEBUG",
 		},


### PR DESCRIPTION
Latest mockserver dockerhub tag is breaking tests in ETA, this pins it to the most recent version tag instead of `latest`.

We should discuss if perhaps all component image tags should be pinned like this.
