### PR TITLE
Add response headers in mockserver client

### DIFF
--- a/docker/component/component_test.go
+++ b/docker/component/component_test.go
@@ -135,12 +135,20 @@ func TestMockServer(t *testing.T) {
 		mockserver.Expectation{
 			Request: mockserver.Request{Method: "GET", Path: "/"},
 			Response: mockserver.Response{
-				Status: 200,
-				Body:   struct{}{},
-				Delay:  &mockserver.Delay{TimeUnit: mockserver.Milliseconds, Value: 100},
+				Status:  200,
+				Body:    struct{}{},
+				Delay:   &mockserver.Delay{TimeUnit: mockserver.Milliseconds, Value: 50},
+				Headers: map[string][]string{"X-TEST": {"test"}},
 			},
+			Times: mockserver.CallTimes{Unlimited: true},
 		})
 	assert.NoError(t, err)
+
+	res, err := http.Get("http://" + mockServerAddr)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, res.StatusCode)
+	assert.Equal(t, "test", res.Header.Get("X-Test"))
+
 	err = mockServerClient.Reset()
 	assert.NoError(t, err)
 }

--- a/docker/component/mockserver/client.go
+++ b/docker/component/mockserver/client.go
@@ -32,9 +32,10 @@ type Delay struct {
 
 // Response is an untyped response from mockserver expectation.
 type Response struct {
-	Status int         `json:"statusCode"`
-	Body   interface{} `json:"body"`
-	Delay  *Delay      `json:"delay,omitempty"`
+	Status  int                 `json:"statusCode"`
+	Body    interface{}         `json:"body"`
+	Delay   *Delay              `json:"delay,omitempty"`
+	Headers map[string][]string `json:"headers,omitempty"`
 }
 
 // CallTimes configures the call times for an expectation.


### PR DESCRIPTION
Please sign your commits following this [guide](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification).
