### PR TITLE
Disable redis protected mode

### DIFF
--- a/docker/component/redis/component.go
+++ b/docker/component/redis/component.go
@@ -27,6 +27,11 @@ func NewComponent(opts ...docker.SimpleContainerOptionFunc) *docker.SimpleCompon
 			ServiceName: "6379",
 		},
 		ReadyFunc: readyFunc,
+		// Disable redis protected mode, in this mode connections are only accepted from the loopback interface
+		// https://hub.docker.com/r/bitnami/redis/
+		RunOpts: &docker.RunOptions{
+			Cmd: []string{"/opt/bitnami/scripts/redis/run.sh", "--protected-mode", "no"},
+		},
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
## Problem

Error during launching redis component (`bitnami/redis` docker container) in component tests.

> test setup failed: starting component "redis": DENIED Redis is running in protected mode because protected mode is enabled and no password is set for the default user. In this mode connections are only accepted from the loopback interface. If you want to connect from external computers to Redis you may adopt one of the following solutions: 1) Just disable protected mode sending the command 'CONFIG SET protected-mode no' from the loopback interface by connecting to Redis from the same host the server is running, however MAKE SURE Redis is not publicly accessible from internet if you do so. Use CONFIG REWRITE to make this change permanent. 2) Alternatively you can just disable the protected mode by editing the Redis configuration file, and setting the protected mode option to 'no', and then restarting the server. 3) If you started the server manually just for testing, restart it with the '--protected-mode no' option. 4) Setup a an authentication password for the default user. NOTE: You only need to do one of the above things in order for the server to start accepting connections from the outside.

Examples of failed runs 
- sonar https://github.com/taxibeat/sonar/runs/6739704411?check_suite_focus=true
- bake test pr https://github.com/taxibeat/bake/pull/225
- bake dependabot pr ci https://github.com/taxibeat/bake/runs/6750903730?check_suite_focus=true

## Solution
Disable protected mode for redis docker container.

Done according to bitnami/redis [documentation](https://hub.docker.com/r/bitnami/redis/)
> Passing extra command-line flags to the redis service command is possible by adding them as arguments to run.sh script:

```bash
$ docker run --name redis -e ALLOW_EMPTY_PASSWORD=yes bitnami/redis:latest /opt/bitnami/scripts/redis/run.sh --maxmemory 100mb
```

Please sign your commits following this [guide](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification).
