### PR TITLE
DIS-4166 Fix bake flags conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,9 @@ bash ./vendor/github.com/taxibeat/bake/scripts/run-bake.sh "$@"
 ```
 
 If you need to pass any custom environment variables to Bake, you can do it 
-by adding one or more `-e` flags to the run-bake script.
+by adding one or more `--env` flags to the run-bake script.
 ```bash
-bash ./vendor/github.com/taxibeat/bake/scripts/run-bake.sh -e SOME_ENV_VAR=some-value "$@"
+bash ./vendor/github.com/taxibeat/bake/scripts/run-bake.sh --env SOME_ENV_VAR=some-value "$@"
 ```
 
 ### 4. Execute

--- a/scripts/run-bake.sh
+++ b/scripts/run-bake.sh
@@ -2,21 +2,17 @@
 
 set -e
 
-# parse parameters in order to pipe custom environment variables to Bake container
+# parse parameters in order to pipe specific flags directly to docker
 DOCKER_ENV=""
-while getopts ":e:" option
-do
-  case "${option}" in
-    e)
-      DOCKER_ENV="${DOCKER_ENV} --env $OPTARG"
-      ;;
-    *)
-      echo "Usage: $(basename "$0") [-e envvar=value] target" >&2
-      exit 1
-      ;;
-  esac
+for param in "$@"; do
+  if [ "$param" == "--env" ]; then
+    shift
+    DOCKER_ENV="${DOCKER_ENV} $param $1"
+    shift
+  else
+    break
+  fi
 done
-shift $(( OPTIND-1 ))
 
 image_name="ghcr.io/taxibeat/bake"
 image_tag=`cat go.mod | grep github.com/taxibeat/bake | cut -f2 -d"v"`


### PR DESCRIPTION
Since Bake uses some flags itself, e.g. `--gen-bin` it conflicts with flags parsing in the `bake-run.sh`. 

Proposed solution - 
- Parse flags manually not using `getops` and bypass anything that comes after `--env` flags to bake as it is.
- Name the flag as in docker (--env) for consistency.