### PR TITLE
Explicitly set mongo version

### DIFF
--- a/docker/component/mongodb/component.go
+++ b/docker/component/mongodb/component.go
@@ -21,7 +21,7 @@ func NewComponent(opts ...docker.SimpleContainerOptionFunc) *docker.SimpleCompon
 	container := docker.SimpleContainerConfig{
 		Name:       componentName,
 		Repository: "mongo",
-		Tag:        "latest",
+		Tag:        "4.4.16",
 		ServicePorts: map[string]string{
 			ServiceName: "27017",
 		},


### PR DESCRIPTION
Mongo latest seems to be broken for all AMD64 based machines, services which use it struggle of CI/CD pipeline failure.

Fix: Set 4.4.16 version explicitly.