### PR TITLE
Report more than default 3 issues with the same text

### DIFF
--- a/targets/lint/golang/golangci.config.yml
+++ b/targets/lint/golang/golangci.config.yml
@@ -30,3 +30,4 @@ linters:
 
 issues:
   exclude-use-default: false
+  max-same-issues: 0


### PR DESCRIPTION
When running the linter it defaults to 3 issues with same text. You have to fix them and rerun it to go to the next 3. This change disbles the limit.

Please sign your commits following this [guide](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification).
