### PR TITLE
Replace localstack with moto-backed awsmock component

### DIFF
--- a/docker/component/awsmock/component.go
+++ b/docker/component/awsmock/component.go
@@ -1,0 +1,65 @@
+// Package awsmock exposes an AWS mock service backed by motoserver/moto.
+package awsmock
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/beatlabs/bake/docker"
+)
+
+const (
+	// ServiceName is the advertised name of this service.
+	ServiceName   = "awsmock"
+	componentName = "awsmock"
+)
+
+// NewComponent creates a new AWS mock component backed by moto.
+// All AWS services are available by default; no explicit service selection is needed.
+func NewComponent(opts ...docker.SimpleContainerOptionFunc) *docker.SimpleComponent {
+	container := docker.SimpleContainerConfig{
+		Name:       componentName,
+		Repository: "motoserver/moto",
+		Tag:        "latest",
+		ServicePorts: map[string]string{
+			ServiceName: "5000",
+		},
+		ReadyFunc: readyFunc,
+	}
+
+	for _, opt := range opts {
+		opt(&container)
+	}
+
+	return &docker.SimpleComponent{
+		Name:       componentName,
+		Containers: []docker.SimpleContainerConfig{container},
+	}
+}
+
+func readyFunc(session *docker.Session) error {
+	addr, err := session.AutoServiceAddress(ServiceName)
+	if err != nil {
+		return err
+	}
+
+	return docker.Retry(func() error {
+		url := fmt.Sprintf("http://%s/moto-api/", addr)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create health request: %w", err)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("got status code: %d from %s", resp.StatusCode, url)
+		}
+		return nil
+	})
+}

--- a/docker/component/component_test.go
+++ b/docker/component/component_test.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/IBM/sarama"
 	"github.com/beatlabs/bake/docker"
+	"github.com/beatlabs/bake/docker/component/awsmock"
 	"github.com/beatlabs/bake/docker/component/consul"
 	"github.com/beatlabs/bake/docker/component/jaeger"
 	"github.com/beatlabs/bake/docker/component/kafka"
-	"github.com/beatlabs/bake/docker/component/localstack"
 	"github.com/beatlabs/bake/docker/component/mockserver"
 	"github.com/beatlabs/bake/docker/component/mongodb"
 	"github.com/beatlabs/bake/docker/component/redis"
@@ -49,7 +49,7 @@ func newSession() {
 		kafka.NewComponent(session, kafka.WithTopics("foo:1:1")),
 		consul.NewComponent(docker.WithTag("1.8.0")),
 		jaeger.NewComponent(),
-		localstack.NewComponent(localstack.WithServices("s3")),
+		awsmock.NewComponent(),
 		mockserver.NewComponent(),
 		redis.NewComponent(),
 		mongodb.NewComponent(),

--- a/docker/component/localstack/component.go
+++ b/docker/component/localstack/component.go
@@ -1,3 +1,5 @@
+// Package localstack is deprecated. Use github.com/beatlabs/bake/docker/component/awsmock instead.
+//
 // Deprecated: Use github.com/beatlabs/bake/docker/component/awsmock instead.
 package localstack
 

--- a/docker/component/localstack/component.go
+++ b/docker/component/localstack/component.go
@@ -1,75 +1,29 @@
-// Package localstack exposes a Localstack service.
+// Deprecated: Use github.com/beatlabs/bake/docker/component/awsmock instead.
 package localstack
 
 import (
-	"context"
-	"fmt"
-	"net/http"
-	"strings"
-
 	"github.com/beatlabs/bake/docker"
+	"github.com/beatlabs/bake/docker/component/awsmock"
 )
 
 const (
 	// ServiceName is the advertised name of this service.
-	ServiceName   = "localstack"
-	componentName = "localstack"
+	//
+	// Deprecated: Use awsmock.ServiceName instead.
+	ServiceName = awsmock.ServiceName
 )
 
-// WithServices sets the localstack services in the container config.
-func WithServices(services ...string) docker.SimpleContainerOptionFunc {
-	return func(c *docker.SimpleContainerConfig) {
-		c.Env = append(c.Env, "LOCALSTACK_SERVICES="+strings.Join(services, ","))
-	}
+// WithServices is a no-op retained for backward compatibility.
+// Moto exposes all AWS services by default.
+//
+// Deprecated: awsmock.NewComponent does not require service selection.
+func WithServices(_ ...string) docker.SimpleContainerOptionFunc {
+	return func(_ *docker.SimpleContainerConfig) {}
 }
 
-// NewComponent creates a new Redis component.
+// NewComponent creates a new AWS mock component.
+//
+// Deprecated: Use awsmock.NewComponent instead.
 func NewComponent(opts ...docker.SimpleContainerOptionFunc) *docker.SimpleComponent {
-	container := docker.SimpleContainerConfig{
-		Name:       componentName,
-		Repository: "localstack/localstack",
-		Tag:        "latest",
-		ServicePorts: map[string]string{
-			ServiceName: "4566",
-		},
-		Env: []string{
-			"LOCALSTACK_DEBUG=1",
-		},
-		ReadyFunc: readyFunc,
-	}
-
-	for _, opt := range opts {
-		opt(&container)
-	}
-
-	return &docker.SimpleComponent{
-		Name:       componentName,
-		Containers: []docker.SimpleContainerConfig{container},
-	}
-}
-
-func readyFunc(session *docker.Session) error {
-	addr, err := session.AutoServiceAddress(ServiceName)
-	if err != nil {
-		return err
-	}
-
-	return docker.Retry(func() error {
-		url := fmt.Sprintf("http://%s/_localstack/health", addr)
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create health request: %w", err)
-		}
-
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("got status code: %d from %s", resp.StatusCode, url)
-		}
-		return nil
-	})
+	return awsmock.NewComponent(opts...)
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `localstack/localstack:latest` image broke — all 9 open dependabot PRs fail CI with exit code 137 (OOM kill) because the localstack container fails to start during `test:coverAll`
- **Fix**: Replace with `motoserver/moto` via a new generic `awsmock` package. Moto is lighter (pure Python, in-memory) and starts reliably
- **Backward compat**: `docker/component/localstack` is preserved but deprecated — it delegates to `awsmock` internally. Existing consumers keep compiling

## Changes

| File | Change |
|---|---|
| `docker/component/awsmock/component.go` | New package: moto backend, port 5000, health check at `/moto-api/` |
| `docker/component/localstack/component.go` | Deprecated — delegates to awsmock, `WithServices()` becomes no-op |
| `docker/component/component_test.go` | Uses `awsmock.NewComponent()` instead of `localstack.NewComponent()` |

## Testing

- `mage test:coverAll` passes locally in ~52s (previously OOM-killed after 6+ min)